### PR TITLE
Only delete expired subscriptions

### DIFF
--- a/graph/delete-subscription/index.js
+++ b/graph/delete-subscription/index.js
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const { BlobServiceClient, BlockBlobClient } = require("@azure/storage-blob");
+const blobServiceClient = BlobServiceClient.fromConnectionString(process.env["AzureWebJobsStorage"]);
+const containerClient = blobServiceClient.getContainerClient('subscriptions');
 const graph = require('../helpers/graph');
 const splunk = require('../helpers/splunk');
 
@@ -30,6 +33,7 @@ module.exports = async function (context, req) {
                 msg = `[delete-subscription] deleted subscription with ID ${subscriptionId}`
                 context.log(msg);
                 splunk.logInfo(msg);
+                containerClient.deleteBlob(subscriptionId);
                 context.res = {
                     body: msg
                 }

--- a/graph/delete-subscription/index.js
+++ b/graph/delete-subscription/index.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const { BlobServiceClient, BlockBlobClient } = require("@azure/storage-blob");
+const { BlobServiceClient } = require("@azure/storage-blob");
 const blobServiceClient = BlobServiceClient.fromConnectionString(process.env["AzureWebJobsStorage"]);
 const containerClient = blobServiceClient.getContainerClient('subscriptions');
 const graph = require('../helpers/graph');

--- a/graph/update-subscriptions/index.js
+++ b/graph/update-subscriptions/index.js
@@ -84,21 +84,13 @@ module.exports = async function (context, myTimer) {
                 blockBlobClient.upload(blobContent, blobContent.length);
             })
             .catch((err) => {
-                if ((err.statusCode = 404) && (!err.message.includes("timed out"))) {
-                    // Looks like this subscription was removed, so remove it from the blob container.
-                    let msg = `[update-subscriptions] a subscription with subscription Id '${subscription.subscriptionId}' was not found from Graph. Removing the blob item...`
-                    context.log.warn(msg);
-                    splunk.logWarning(msg);
-                    containerClient.deleteBlob(subscription.subscriptionId);
-                } else {
-                    let errorMsg = `[update-subscriptions] could not update subscription from Graph: ${subscription.subscriptionId}, error: ${JSON.stringify(err)}`
-                    context.log.error(errorMsg);
-                    splunk.logError(errorMsg);
-                    context.res = {
-                        body: errorMsg
-                    };
-                    return;
-                }
+                let errorMsg = `[update-subscriptions] could not update subscription from Graph: ${subscription.subscriptionId}, error: ${JSON.stringify(err)}`
+                context.log.error(errorMsg);
+                splunk.logError(errorMsg);
+                context.res = {
+                    body: errorMsg
+                };
+                return;
             });
 
     }

--- a/graph/update-subscriptions/index.js
+++ b/graph/update-subscriptions/index.js
@@ -111,7 +111,7 @@ function subscriptionHasExpired(expirationDateTime) {
     let now = new Date();
 
     // has it expired
-    return subscriptionExpirationDateTime > now;
+    return subscriptionExpirationDateTime < now;
 }
 
 function subscriptionExpiresSoon(expirationDateTime) {


### PR DESCRIPTION
Change the logic of the update-subscription function so it only remove subscriptions from the blob store if they are passed their expiry date.
Update the delete-subscription function to also remove the subscription from the blob store.