### PR TITLE
chore: bump node and Azure function versions

### DIFF
--- a/event-hubs-hec/deploy/azureDeploy.json
+++ b/event-hubs-hec/deploy/azureDeploy.json
@@ -287,11 +287,11 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "~12"
+                            "value": "~18"
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",


### PR DESCRIPTION
Node bumped to ~18
Azure Functions bumped to ~4