### PR TITLE
Storage HEC - Add support for VNet flow

### DIFF
--- a/storage-hec/README.md
+++ b/storage-hec/README.md
@@ -40,21 +40,52 @@ Refer to the Microsoft documentation for [Azure Storage Account setup instructio
 
 Use the "Deploy to Azure" button above to deploy the Azure Functions from this repo to your Azure account.  During setup, you will be prompted for the following information:
 
-* Blob Path - this is the blob container containing the NSG Flow logs
-* Blob Connection String - this is the connection string for the Azure Storage Account
-* NSG Sourcetype
-* Splunk [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) Endpoint
-* Splunk [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) Token
-* Denormalize Events
-  * If true, each flow tuple will be a separate Splunk event
-  * If false, each Splunk event will contain multiple flow tuples
-  * Note: see the [NSG log format](https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview#log-format) for more details.
+* **NSG Blob Container/Path** - this is the blob container containing the NSG Flow logs
+* **Blob Connection String** - this is the connection string for the Azure Storage Account
+* **NSG Flow Log Source Type** - this is the source type of the NSG flow logs when ingested into Splunk [default: `azure:nsg:flowlog`]
+* **VNet Blob Container/Path** - this is the blob container containing the NSG Flow logs
+* **VNet Blob Connection String** - this is the connection string for the Azure Storage Account
+* **VNet Flow Log Source Type** - this is the source type of the VNet flow logs when ingested into Splunk [default: `azure:vnet:flowlog`]
+* **Denormalize Events**
+  * If **true**, each flow tuple will be a separate Splunk event
+  * If **false**, each Splunk event will contain multiple flow tuples
+  * Note: see the [NSG flow log format](https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview#log-format) & [VNet flow log format](https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview?tabs=Americas#log-format) for more details.
+* **Convert Tuple to JSON**
+  * If **true**, all NSG/VNet flow log tuples will be converted from CSV to JSON. Additionally, the JSON will be enriched with all attributes from higher levels in the flow record (e.g., mac, rule, flowLogResourceID, targetResourceID, etc.).
+  * If **false**, all NSG/VNet flow log tuples will remain their original CSV format and no enrichment will occur.
+  * Note: This is ignored when `Denormalize Events` is set to **false**
+  * Default: **true**
+* **Process NSG Flow**
+  * If **true**, new NSG flow records created in the blob container's blob path will be parsed and sent to Splunk.
+  * If **false**, all new NSG flow log records will be ignored.
+  * Default: **true**
+* **Process VNet Flow**
+  * If **true**, new VNet flow records created in the blob container's blob path will be parsed and sent to Splunk.
+  * If **false**, all new VNet flow log records will be ignored.
+  * Default: **true**
+* **Splunk [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) Endpoint** - The full HEC url for JSON events (e.g., `https://hec.splunk.my.org:443/services/collector/event`)
+* **Splunk [HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) Token** - GUID associated with the HEC input
 
 
 ## Securing Azure Function settings
 Microsoft stores the above values as [application settings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings#settings). These settings are stored encrypted, but you may opt to transfer one or more of these settings to a Key Vault. Refer to the following documentation for details on this procedure:
 
 * [Use Key Vault references for App Service and Azure Functions](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+
+### App Settings:
+1. `PROCESS_NSG_FLOW` = see "Process NSG Flow"
+1. `BLOB_PATH` = see "NSG Blob Container/Path"
+1. `BLOB_CONNECTION_STRING` = see "NSG Blob Connection String"
+1. `NSG_SOURCETYPE` = see "NSG Flow Log Source Type"
+1. `PROCESS_VNET_FLOW` = see "Process VNet Flow"
+1. `VNET_BLOB_PATH` = see "VNet Blob Container/Path"
+1. `VNET_BLOB_CONNECTION_STRING` = see "VNet Blob Connection String"
+1. `VNET_SOURCETYPE` = see "VNet Flow Log Source Type"
+1. `DENORMALIZE_EVENTS` = see "Denormalize Events"
+1. `CONVERT_TUPLE_TO_JSON` = see "Convert Tuple to JSON"
+1. `SPLUNK_HEC_URL` = see "Splunk HEC Endpoint"
+1. `SPLUNK_HEC_TOKEN` = see "Splunk HEC Token"
+
 
 ## Support
 This software is released as-is. Splunk provides no warranty and no support on this software. If you have any issues with the software, please file an issue on the repository.

--- a/storage-hec/blob-nsg-hec/index.js
+++ b/storage-hec/blob-nsg-hec/index.js
@@ -14,15 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 const splunk = require('../helpers/splunk');
+const process_nsg_flow = (process.env['PROCESS_NSG_FLOW'] === undefined || process.env['PROCESS_NSG_FLOW'].toLowerCase() === 'true')
 module.exports = async function (context) {
+    if(process_nsg_flow) {
+        await splunk
+                .sendToHEC(context.bindings.nsgBlobInput)
+                .catch(err => {
+                    context.log.error(`Error posting to Splunk HTTP Event Collector: ${err}`);
 
-    await splunk
-            .sendToHEC(context.bindings.nsgBlobInput)
-            .catch(err => {
-                context.log.error(`Error posting to Splunk HTTP Event Collector: ${err}`);
-
-                // If the event was not successfully sent to Splunk, drop the event in a storage blob container undeliverable-nsg-events
-                context.bindings.outputBlob = context.bindings.nsgBlobInput;
-            })
+                    // If the event was not successfully sent to Splunk, drop the event in a storage blob container undeliverable-nsg-events
+                    context.bindings.outputBlob = context.bindings.nsgBlobInput;
+                })
+    }
+    else {
+        context.log.warn("Skipping NSG flow logs since this functionality is disabled. In order to process NSG flow logs, either set the environment variable 'PROCESS_NSG_FLOW' to 'true' or remove it.")
+    }
     context.done();
 };

--- a/storage-hec/blob-vnet-hec/function.json
+++ b/storage-hec/blob-vnet-hec/function.json
@@ -1,0 +1,27 @@
+{
+  "bindings": [
+    {
+      "type": "blobTrigger",
+      "name": "vnetBlobTrigger",
+      "direction": "in",
+      "connection": "VNET_BLOB_CONNECTION_STRING",
+      "dataType": "string",
+      "path": "%VNET_BLOB_PATH%/{name}"
+    },
+    {
+      "type": "blob",
+      "name": "vnetBlobInput",
+      "direction": "in",
+      "connection": "VNET_BLOB_CONNECTION_STRING",
+      "dataType": "string",
+      "path": "%VNET_BLOB_PATH%/{name}"
+    },
+    {
+      "name": "outputBlob",
+      "type": "blob",
+      "path": "undeliverable-vnet-events/{rand-guid}-{name}",
+      "connection": "VNET_BLOB_CONNECTION_STRING",
+      "direction": "out"
+    }
+  ]
+}

--- a/storage-hec/blob-vnet-hec/index.js
+++ b/storage-hec/blob-vnet-hec/index.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 Splunk Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const splunk = require('../helpers/splunk');
+const process_vnet_flow = (process.env['PROCESS_VNET_FLOW'] === undefined || process.env['PROCESS_VNET_FLOW'].toLowerCase() === 'true')
+module.exports = async function (context) {
+    if(process_vnet_flow) {
+        await splunk
+                .sendToHEC(context.bindings.vnetBlobInput)
+                .catch(err => {
+                    context.log.error(`Error posting to Splunk HTTP Event Collector: ${err}`);
+
+                    // If the event was not successfully sent to Splunk, drop the event in a storage blob container undeliverable-vnet-events
+                    context.bindings.outputBlob = context.bindings.vnetBlobInput;
+                })
+    }
+    else {
+        context.log.warn("Skipping VNet flow logs since this functionality is disabled. In order to process VNet flow logs, either set the environment variable 'PROCESS_VNET_FLOW' to 'true' or remove it.")
+    }
+    context.done();
+};

--- a/storage-hec/deploy/azureDeploy.json
+++ b/storage-hec/deploy/azureDeploy.json
@@ -38,6 +38,12 @@
                 "description": "Connection string for the storage account storing the NSG flow logs"
             }
         },
+        "processNsgFlow": {
+            "type": "bool",
+            "metadata": {
+                "description": "Whether or not to process new NSG flow records created in the \"Blob Container's\" \"Blob Path\""
+            }
+        },
         "nsgContainer": {
             "type": "string",
             "defaultValue": "insights-logs-networksecuritygroupflowevent",
@@ -52,23 +58,43 @@
                 "description": "Splunk source type for the NSG flow logs"
             }
         },
+        "processVnetFlow": {
+            "type": "bool",
+            "metadata": {
+                "description": "Whether or not to process new VNet flow records created in the \"VNet Blob Container's\" \"VNet Blob Path\""
+            }
+        },
+        "vnetConnectionString": {
+            "type": "string",
+            "metadata": {
+                "description": "Connection string for the storage account storing the VNet flow logs"
+            }
+        },
+        "vnetContainer": {
+            "type": "string",
+            "defaultValue": "insights-logs-flowlogsflowevent",
+            "metadata": {
+                "description": "Blob container for VNet flow logs"
+            }
+        },
+        "vnetSourceType": {
+            "type": "string",
+            "defaultValue": "azure:vnet:flowlog",
+            "metadata": {
+                "description": "Splunk source type for the VNet flow logs"
+            }
+        },
         "denormalizeEvents": {
             "type": "bool",
             "metadata": {
-                "description": ""
+                "description": "Whether or not to separate flow tuples into individual Splunk events"
             }
         },
-        "githubRepoURL": {
-            "type": "string",
-            "defaultValue": "https://github.com/splunk/azure-functions-splunk.git"
-        },
-        "githubRepoBranch": {
-            "type": "string",
-            "defaultValue": "master"
-        },
-        "githubRepoProject": {
-            "type": "string",
-            "defaultValue": "storage-hec"
+        "convertTupleToJson": {
+            "type": "bool",
+            "metadata": {
+                "description": "Whether or not to keep the original tuple format or convert it to json and enrich it with its parental JSON attributes from the overall flow record"
+            }
         },
         "SplunkEndpoint": {
             "type": "string",
@@ -141,11 +167,11 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "~12"
+                            "value": "~22"
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "SPLUNK_HEC_TOKEN",
@@ -156,43 +182,48 @@
                             "value": "[parameters('SplunkEndpoint')]"
                         },
                         {
-                            "name": "Project",
-                            "value": "[parameters('githubRepoProject')]"
+                            "name": "PROCESS_NSG_FLOW",
+                            "value": "[parameters('processNsgFlow')]"
+                        },
+                        {
+                            "name": "PROCESS_VNET_FLOW",
+                            "value": "[parameters('processVnetFlow')]"
                         },
                         {
                             "name": "BLOB_PATH",
                             "value": "[parameters('nsgContainer')]"
                         },
                         {
+                            "name": "VNET_BLOB_PATH",
+                            "value": "[parameters('vnetContainer')]"
+                        },
+                        {
                             "name": "BLOB_CONNECTION_STRING",
                             "value": "[parameters('nsgConnectionString')]"
+                        },
+                        {
+                            "name": "VNET_BLOB_CONNECTION_STRING",
+                            "value": "[parameters('vnetConnectionString')]"
                         },
                         {
                             "name": "NSG_SOURCETYPE",
                             "value": "[parameters('nsgSourceType')]"
                         },
                         {
+                            "name": "VNET_SOURCETYPE",
+                            "value": "[parameters('vnetSourceType')]"
+                        },
+                        {
                             "name": "DENORMALIZE_EVENTS",
                             "value": "[parameters('denormalizeEvents')]"
+                        },
+                        {
+                            "name": "CONVERT_TUPLE_TO_JSON",
+                            "value": "[parameters('convertTupleToJson')]"
                         }
                     ]
                 }
-            },
-            "resources": [
-                {
-                    "apiVersion": "2016-08-01",
-                    "name": "web",
-                    "type": "sourcecontrols",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', variables('functionAppName'))]"
-                    ],
-                    "properties": {
-                        "RepoUrl": "[parameters('githubRepoURL')]",
-                        "branch": "[parameters('githubRepoBranch')]",
-                        "IsManualIntegration": true
-                    }
-                }
-            ] 
+            }
         }
     ]
 }

--- a/storage-hec/deploy/azureDeploy.portal.json
+++ b/storage-hec/deploy/azureDeploy.portal.json
@@ -87,34 +87,125 @@
                 "label": "NSG Location Details",
                 "elements": [
                     {
-                        "name": "nsgConnectionString",
-                        "label": "Storage Account Connection String",
-                        "type": "Microsoft.Common.TextBox",
-                        "toolTip": "The connection string to the stroage account containing NSG Flow Logs",
+                        "name": "processNsgFlow",
+                        "label": "Process NSG Flow",
+                        "type": "Microsoft.Common.DropDown",
+                        "toolTip": "",
+                        "defaultValue": ["True"],
+                        "multiselect": false,
+                        "multiLine": true,
                         "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "True",
+                                    "description": "Process new NSG flow records created in the NSG blob container",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "False",
+                                    "description": "Ignore all new NSG flow records created in the NSG blob container",
+                                    "value": "false"
+                                }
+                            ],
                             "required": true
+                        }
+                    },
+                    {
+                        "name": "nsgConnectionString",
+                        "label": "NSG Storage Account Connection String",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "The connection string to the storage account containing NSG Flow Logs",
+                        "constraints": {
+                            "required": false
                         }
                     },
                     {
                         "name": "nsgContainer",
-                        "label": "NSG Container",
+                        "label": "NSG Blob Container/Path",
                         "type": "Microsoft.Common.TextBox",
                         "toolTip": "The blob container that contains the NSG Flow Logs",
                         "defaultValue": "insights-logs-networksecuritygroupflowevent",
+                        "constraints": {
+                            "required": false
+                        }
+                    },
+                    {
+                        "name": "nsgSourcetype",
+                        "label": "NSG Flow Log Source Type",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "Splunk Source type for the NSG Flow Logs",
+                        "defaultValue": "azure:nsg:flowlog",
+                        "constraints": {
+                            "required": false
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "vnetSection",
+                "type": "Microsoft.Common.Section",
+                "label": "VNet Location Details",
+                "elements": [
+                    {
+                        "name": "processVnetFlow",
+                        "label": "Process VNet Flow",
+                        "type": "Microsoft.Common.DropDown",
+                        "toolTip": "",
+                        "defaultValue": ["True"],
+                        "multiselect": false,
+                        "multiLine": true,
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "True",
+                                    "description": "Process new VNet flow records created in the VNet blob container",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "False",
+                                    "description": "Ignore all new VNet flow records created in the VNet blob container",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "vnetConnectionString",
+                        "label": "VNet Storage Account Connection String",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "The connection string to the storage account containing VNet Flow Logs",
                         "constraints": {
                             "required": true
                         }
                     },
                     {
-                        "name": "nsgSourcetype",
-                        "label": "NSG Source Type",
+                        "name": "vnetContainer",
+                        "label": "VNet Blob Container/Path",
                         "type": "Microsoft.Common.TextBox",
-                        "toolTip": "Splunk Souretype for the NSG Logs",
-                        "defaultValue": "azure:nsg:flowlog",
+                        "toolTip": "The blob container that contains the VNet Flow Logs",
+                        "defaultValue": "insights-logs-flowlogflowevent",
                         "constraints": {
                             "required": true
                         }
                     },
+                    {
+                        "name": "vnetSourcetype",
+                        "label": "VNet Flow Log Source Type",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "Splunk Source type for the VNet Flow Logs",
+                        "defaultValue": "azure:vnet:flowlog",
+                        "constraints": {
+                            "required": true
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "parsingSection",
+                "type": "Microsoft.Common.Section",
+                "label": "Parsing Settings",
+                "elements": [
                     {
                         "name": "denormalizeEvents",
                         "label": "Denormalize Events",
@@ -133,6 +224,30 @@
                                 {
                                     "label": "False",
                                     "description": "Keep multiple flow tuples in a single Splunk event",
+                                    "value": "false"
+                                }
+                            ],
+                            "required": true
+                        }
+                    },
+                    {
+                        "name": "convertTupleToJson",
+                        "label": "Convert Tuple to JSON",
+                        "type": "Microsoft.Common.DropDown",
+                        "toolTip": "",
+                        "defaultValue": ["True"],
+                        "multiselect": false,
+                        "multiLine": true,
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "True",
+                                    "description": "Change the format of the flow tuple to JSON, adding parental JSON attributes from the overall flow record",
+                                    "value": "true"
+                                },
+                                {
+                                    "label": "False",
+                                    "description": "Keep the original flow tuple format and do NOT add any parental JSON attributes from the overall flow record",
                                     "value": "false"
                                 }
                             ],
@@ -206,10 +321,16 @@
             "appName": "[steps('basics').appName]",
             "storageAccountType": "[steps('basics').storageAccountType]",
             "storageAccountTLS": "[steps('basics').storageAccountTLS]",
+            "processNsgFlow": "[steps('basics').nsgSection.processNsgFlow]",
             "nsgConnectionString": "[steps('basics').nsgSection.nsgConnectionString]",
             "nsgContainer": "[steps('basics').nsgSection.nsgContainer]",
             "nsgSourceType": "[steps('basics').nsgSection.nsgSourcetype]",
-            "denormalizeEvents": "[steps('basics').nsgSection.denormalizeEvents]",
+            "processVnetFlow": "[steps('basics').vnetSection.processVnetFlow]",
+            "vnetConnectionString": "[steps('basics').vnetSection.vnetConnectionString]",
+            "vnetContainer": "[steps('basics').vnetSection.vnetContainer]",
+            "vnetSourceType": "[steps('basics').vnetSection.vnetSourcetype]",
+            "denormalizeEvents": "[steps('basics').parsingSection.denormalizeEvents]",
+            "convertTupleToJson": "[steps('basics').parsingSection.convertTupleToJson]",
             "SplunkEndpoint": "[steps('basics').splunkHECSection.splunkHECEndpoint]",
             "SplunkToken": "[steps('basics').splunkHECSection.splunkHECToken]",
             "githubRepoURL": "[steps('basics').repoSection.repoURL]",

--- a/storage-hec/helpers/splunk.js
+++ b/storage-hec/helpers/splunk.js
@@ -34,48 +34,158 @@ const getTimeStamp = function(message) {
 const getHECPayload = async function(blobContent) {
 
     let denormalize = (process.env["DENORMALIZE_EVENTS"].toLowerCase() === 'true')
+    let convert_tuple_to_json = (process.env["CONVERT_TUPLE_TO_JSON"] === undefined || process.env["CONVERT_TUPLE_TO_JSON"].toLowerCase() === 'true')
     let sourcetype = process.env["NSG_SOURCETYPE"]
+    let vnet_sourcetype = process.env["VNET_SOURCETYPE"]
     let payload = ''
     
+    // NSG flow logs
     // https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview
+
+    // VNet flow logs
+    // https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview
     let records = blobContent.records
 
     records.forEach(function(record) {
+        
+        const is_vnetflow = (record.category == 'FlowLogFlowEvent')
 
         if (denormalize) {
-            // Make each flow tuple its own distinct Splunk event
-            for (i in record.properties.flows) {
-                let flow = record.properties.flows[i]
-    
-                for (i in flow.flows) {
-                    let ruleFlow = flow.flows[i]
-    
-                    for (i in ruleFlow.flowTuples) {
-                        let ruleFlowTuple = ruleFlow.flowTuples[i]
-                        
-                        let splunkEvent = {}
-                        splunkEvent["time"] = record.time
-                        splunkEvent["systemId"] = record.systemId
-                        splunkEvent["category"] = record.category
-                        splunkEvent["resourceId"] = record.resourceId
-                        splunkEvent["operationName"] = record.operationName
-                        splunkEvent["version"] = record.properties.Version
-                        splunkEvent["rule"] = flow.rule
-                        splunkEvent["mac"] = ruleFlow.mac
-                        splunkEvent["flowTuple"] = ruleFlowTuple
-    
-                        let recordEvent = {
-                            "event": JSON.stringify(splunkEvent),
-                            "sourcetype": sourcetype
+            if(!is_vnetflow) {
+                // NSG flow
+                // Make each flow tuple its own distinct Splunk event
+                for (i in record.properties.flows) {
+                    let flow = record.properties.flows[i]
+        
+                    for (i in flow.flows) {
+                        let ruleFlow = flow.flows[i]
+        
+                        for (i in ruleFlow.flowTuples) {
+                            let ruleFlowTuple = ruleFlow.flowTuples[i]
+                            
+                            let splunkEvent = {}
+                            if(convert_tuple_to_json) {
+                                let flowTuple = flowGroup.flowTuples[i].split(',')
+                                splunkEvent["time"] = Number(flowTuple[0])
+                                splunkEvent["sourceAddress"] = flowTuple[1]
+                                splunkEvent["destinationAddress"] = flowTuple[2]
+                                splunkEvent["sourcePort"] = flowTuple[3]
+                                splunkEvent["destinationPort"] = flowTuple[4]
+                                splunkEvent["protocol"] = flowTuple[5]
+                                splunkEvent["deviceDirection"] = flowTuple[6]
+                                splunkEvent["deviceAction"] = flowTuple[7]
+                                if(Number(record.properties.Version) == 2) {
+                                    splunkEvent["flowState"] = flowTuple[8]
+                                    if(flowTuple[9] != '') {
+                                        splunkEvent["packetsStoD"] = Number(flowTuple[9])
+                                    } 
+                                    if(flowTuple[10] != '') {
+                                        splunkEvent["bytesStoD"] = Number(flowTuple[10])
+                                    } 
+                                    if(flowTuple[11] != '') {
+                                        splunkEvent["packetsDtoS"] = Number(flowTuple[11])
+                                    } 
+                                    if(flowTuple[12] != '') {
+                                        splunkEvent["bytesDtoS"] = Number(flowTuple[12])
+                                    }
+                                }
+
+                            }
+                            else {
+                                let flowTuple = flowGroup.flowTuples[i]
+                                // Extracting the epoch from the tuple since it's when the traffic occurred, 
+                                //  whereas the value in the "time" attribute of the record is when it was logged.
+                                splunkEvent["time"] = Number(flowTuple.substr(0, flowTuple.indexOf(',')))
+                                splunkEvent["flowTuple"] = flowTuple
+                            }
+                            splunkEvent["systemId"] = record.systemId
+                            splunkEvent["category"] = record.category
+                            splunkEvent["resourceId"] = record.resourceId
+                            splunkEvent["operationName"] = record.operationName
+                            splunkEvent["version"] = record.properties.Version
+                            splunkEvent["rule"] = flow.rule
+                            splunkEvent["mac"] = ruleFlow.mac
+        
+                            let recordEvent = {
+                                "event": JSON.stringify(splunkEvent),
+                                "sourcetype": sourcetype
+                            }
+                            // Prioritize the tuple's timestamp over the flow record's
+                            let eventTimeStamp = splunkEvent['time'] || getTimeStamp(record);
+                            if(eventTimeStamp) { recordEvent["time"] = eventTimeStamp; }
+                            payload += JSON.stringify(recordEvent);
                         }
-                        let eventTimeStamp = getTimeStamp(record);
-                        if(eventTimeStamp) { recordEvent["time"] = eventTimeStamp; }
-                        payload += JSON.stringify(recordEvent);
                     }
                 }
             }
+            else {
+                // Vnet flow
+                for (i in record.flowRecords.flows) {
+                    let flow = record.flowRecords.flows[i];
+
+                    for (i in flow.flowGroups) {
+                        let flowGroup = flow.flowGroups[i];
+                        
+                        for (i in flowGroup.flowTuples) {
+                            let splunkEvent = {}
+
+                            if(convert_tuple_to_json) {
+                                let flowTuple = flowGroup.flowTuples[i].split(',')
+                                splunkEvent["time"] = Number(flowTuple[0])
+                                splunkEvent["sourceAddress"] = flowTuple[1]
+                                splunkEvent["destinationAddress"] = flowTuple[2]
+                                splunkEvent["sourcePort"] = flowTuple[3]
+                                splunkEvent["destinationPort"] = flowTuple[4]
+                                splunkEvent["protocol"] = flowTuple[5]
+                                splunkEvent["deviceDirection"] = flowTuple[6]
+                                splunkEvent["flowState"] = flowTuple[7]
+                                splunkEvent["encryption"] = flowTuple[8]                                
+                                if(flowTuple[9] != '') {
+                                    splunkEvent["packetsStoD"] = Number(flowTuple[9])
+                                } 
+                                if(flowTuple[10] != '') {
+                                    splunkEvent["bytesStoD"] = Number(flowTuple[10])
+                                } 
+                                if(flowTuple[11] != '') {
+                                    splunkEvent["packetsDtoS"] = Number(flowTuple[11])
+                                } 
+                                if(flowTuple[12] != '') {
+                                    splunkEvent["bytesDtoS"] = Number(flowTuple[12])
+                                }
+                            }
+                            else {
+                                let flowTuple = flowGroup.flowTuples[i]
+                                // Extracting the epoch from the tuple since it's when the traffic occurred, 
+                                //  whereas the value in the "time" attribute of the record is when it was logged.
+                                splunkEvent["time"] = Number(flowTuple.substr(0, flowTuple.indexOf(',')))
+                                splunkEvent["flowTuple"] = flowTuple
+                            }
+                            splunkEvent["flowLogVersion"] = record.flowLogVersion
+                            splunkEvent["flowLogGUID"] = record.flowLogGUID
+                            splunkEvent["mac"] = record.macAddress
+                            splunkEvent["flowLogResourceID"] = record.flowLogResourceID
+                            splunkEvent["targetResourceID"] = record.targetResourceID
+                            splunkEvent["operationName"] = record.operationName
+                            splunkEvent["aclID"] = flow.aclID
+                            splunkEvent["rule"] = flowGroup.rule
+                            
+                            let recordEvent = {
+                                "event": JSON.stringify(splunkEvent),
+                                "sourcetype": vnet_sourcetype
+                            }
+                            // Prioritize the tuple's timestamp over the flow record's
+                            let eventTimeStamp = splunkEvent['time'] || getTimeStamp(record);
+                            if(eventTimeStamp) { recordEvent["time"] = eventTimeStamp; }
+                            payload += JSON.stringify(recordEvent);
+
+                        }
+                    }
+                }
+            }
+
+
         } else {
-            // Make each record its own distince Splunk event
+            // Make each record its own distinct Splunk event
             let recordEvent = {
                 "event": JSON.stringify(record),
                 "sourcetype": sourcetype

--- a/storage-hec/host.json
+++ b/storage-hec/host.json
@@ -10,6 +10,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.3.0, 4.0.0)"
+    "version": "[4.*,5.0.0)"
   }
 }

--- a/storage-hec/package-lock.json
+++ b/storage-hec/package-lock.json
@@ -1,66 +1,103 @@
 {
   "name": "storage-hec",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "asynckit": {
+  "packages": {
+    "": {
+      "name": "storage-hec",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": ">=0.21.2"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "axios": {
+    "node_modules/axios": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
       "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
-      "requires": {
+      "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
     },
-    "combined-stream": {
+    "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
+      "dependencies": {
         "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "delayed-stream": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "follow-redirects": {
+    "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
-    "form-data": {
+    "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
+      "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
+      "dependencies": {
         "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "proxy-from-env": {
+    "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="


### PR DESCRIPTION
## Summary of Changes
1. Adds a new function `blob-vnet-hec` to the `storage-hec` function app that processes VNet flow logs, while maintaining similar output format as the `blob-nsg-hec` function.
    * Note: This function uses separate app settings than those used by "blob-nsg-hec" so as to not interfere with any pre-existing deployments (see `VNET_BLOB_CONNECTION_STRING`, `VNET_BLOB_PATH`, & `VNET_SOURCETYPE` [default: `azure:vnet:flowlog`].
1. Adds an app setting to allow for maintaining the original tuple format or convert it to JSON (see `CONVERT_TUPLE_TO_JSON` [default: `true`])
1. Adds two app settings, each of which allow the user to prevent the corresponding function from processing new flow logs [default: `true`] (see `PROCESS_NSG_FLOW` [default: `true`] & `PROCESS_VNET_FLOW` [default: `true`])
    * Note: The function for the corresponding app setting will only process new logs if 
        1. the app setting does not exist or 
        1. it is set to "true"
    * The helps ensure any pre-existing deployments continue to operate when they are updated, since they won't have the app setting configured.
1. Updates the documentation with details about the VNet flow function and clarifications on pre-existing details.
1. Updates the Azure portal deployment UI to support the new app settings.
1. Updates the JS environment of the `storage-hec` function app.